### PR TITLE
Fix lambda for C++20

### DIFF
--- a/Source/TolgeeEditor/Private/TolgeeEditorIntegrationSubsystem.cpp
+++ b/Source/TolgeeEditor/Private/TolgeeEditorIntegrationSubsystem.cpp
@@ -431,7 +431,7 @@ void UTolgeeEditorIntegrationSubsystem::Initialize(FSubsystemCollectionBase& Col
 	{
 		MainFrameModule.OnMainFrameCreationFinished().AddWeakLambda(
 			this,
-			[=](TSharedPtr<SWindow> InRootWindow, bool bIsRunningStartupDialog)
+			[=, this](TSharedPtr<SWindow> InRootWindow, bool bIsRunningStartupDialog)
 			{
 				OnMainFrameReady();
 			}


### PR DESCRIPTION
C4855 thrown when building module from source on UE5.3

Compile [x64] Module.TolgeeEditor.cpp
10>TolgeeEditorIntegrationSubsystem.cpp(436): Error C4855 : implicit capture of 'this' via '[=]' is deprecated in '/std:c++20'