### PR TITLE
Update EngineVersion

### DIFF
--- a/Tolgee.uplugin
+++ b/Tolgee.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "VersionName": "0.1",
-  "EngineVersion": "5.3",
+  "EngineVersion": "5.3.0",
   "FriendlyName": "Tolgee",
   "Description": "Localization tool which makes the localization process simple. Easy to integrate to React, Angular and other applications.",
   "Category" : "Localization",


### PR DESCRIPTION
Sorry for bothering you, but here is another minor proposition
If you look at FEngineVersion::Parse, then you would notice that EngineVersion field supposed to have Major.Minor.Patch version 

Currently it's just a warning, but still thought that you might agree on this change
(Also double checked that in 4.26 FEngineVersion::Parse works exactly the same)