### PR TITLE
Add option to not open dashboard on startup & add .idea/ folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Binaries/
 Intermediate/
+.idea/

--- a/Source/Tolgee/Public/TolgeeSettings.h
+++ b/Source/Tolgee/Public/TolgeeSettings.h
@@ -54,6 +54,11 @@ public:
 	UPROPERTY(Config, EditAnywhere, Category = "Tolgee Localization")
 	bool bLiveTranslationUpdates = true;
 	/**
+	 * @brief Should we automatically open LocalizationDashboard on startup?
+	 */
+	UPROPERTY(Config, EditAnywhere, Category = "Tolgee Localization")
+	bool bOpenDashboardOnStartup = false;
+	/**
 	 * @brief How often we should update the translation data from the server
 	 * @note in seconds
 	 */

--- a/Source/TolgeeEditor/Private/TolgeeEditor.cpp
+++ b/Source/TolgeeEditor/Private/TolgeeEditor.cpp
@@ -2,8 +2,8 @@
 
 #include "TolgeeEditor.h"
 
-#include <LevelEditor.h>
 #include <Interfaces/IPluginManager.h>
+#include <LevelEditor.h>
 
 #include "STolgeeTranslationTab.h"
 #include "TolgeeEditorIntegrationSubsystem.h"
@@ -36,7 +36,11 @@ void FTolgeeEditorModule::ActivateWindowTab()
 void FTolgeeEditorModule::StartupModule()
 {
 	RegisterStyle();
-	RegisterWindowExtension();
+	const UTolgeeSettings* TolgeeSettings = GetDefault<UTolgeeSettings>();
+	if (!TolgeeSettings || TolgeeSettings->bOpenDashboardOnStartup)
+	{
+		RegisterWindowExtension();
+	}
 	RegisterToolbarExtension();
 }
 


### PR DESCRIPTION
2 propositions at once

1. I'm using JetBrains Rider and it generates .idea/ folder with IDE configs, so it would be helpful to add it to gitignore (also could suggest to add .vs/ to gitignore)
2. it's quite annoying that localization dashboard opens on each editor startup, especially considering that most of the team don't work with localization. So my suggestion is simple - lets add option in settings to allow to disable it (I put this settings into ProjectSettings, but I can move it to editor settings or to separate category)