### PR TITLE
Added workflow for manual handling of Translations.json

### DIFF
--- a/Source/Tolgee/Public/TolgeeSettings.h
+++ b/Source/Tolgee/Public/TolgeeSettings.h
@@ -64,7 +64,11 @@ public:
 	 */
 	UPROPERTY(Config, EditAnywhere, Category = "Tolgee Localization", meta = (EditCondition = "bLiveTranslationUpdates", UIMin = "0"))
 	float UpdateInterval = 60.0f;
-
+	/**
+	 * @brief Automatically fetch Translations.json on cook
+	 */
+	UPROPERTY(Config, EditAnywhere, Category = "Tolgee Localization")
+	bool bFetchTranslationsOnCook = true;
 private:
 	// Begin UDeveloperSettings interface
 	virtual FName GetContainerName() const override;

--- a/Source/TolgeeEditor/Private/TolgeeEditor.cpp
+++ b/Source/TolgeeEditor/Private/TolgeeEditor.cpp
@@ -201,6 +201,18 @@ void FTolgeeEditorModule::ExtendToolbar(FToolBarBuilder& Builder)
 						}
 					))
 				);
+				
+				MenuBuilder.AddMenuEntry(
+					LOCTEXT("DownloadTranslations", "Download Translations.json"),
+					LOCTEXT("DownloadTranslationsTip", "Download the latest Translations.json file from Tolgee and add it to VCS"),
+					FSlateIcon(),
+					FUIAction(FExecuteAction::CreateLambda(
+						[]()
+						{
+							GEditor->GetEditorSubsystem<UTolgeeEditorIntegrationSubsystem>()->DownloadTranslationsJson();
+						}
+					))
+				);
 
 				return MenuBuilder.MakeWidget();
 			}

--- a/Source/TolgeeEditor/Private/TolgeeEditorIntegrationSubsystem.h
+++ b/Source/TolgeeEditor/Private/TolgeeEditorIntegrationSubsystem.h
@@ -29,14 +29,21 @@ public:
 	 * Collects the local keys and fetches the remotes keys. After comparing the 2, it lets the users chose how to update the keys
 	 */
 	void Sync();
-
+	/**
+	 * Downloads the latest translations from the backend and updates the Translations.json file in the project 
+	 */
 	void DownloadTranslationsJson();
 
 private:
+	/**
+	 * Ensures that the file is checked out if it's source controlled.
+	 */
 	bool EnsureFileCheckedOutSourceControl(FString FilePath);
-
-	bool EnsureFileFileAddedSourceControl(FString FilePath, bool bWasFileModified);
-	
+	/**
+	 * Ensures that the file is added to source control if it was modified
+	 * If it was not modified it will ensure that the file does not remain checked out
+	 */
+	bool EnsureAddedStateSourceControl(FString FilePath, bool bWasFileModified);
 	/**
 	 * Sends a request to the backend to import new keys
 	 */
@@ -78,9 +85,9 @@ private:
 	 */
 	void OnMainFrameReady(TSharedPtr<SWindow> InRootWindow, bool bIsRunningStartupDialog);
 	/**
-	 * @brief Exports the locally available data to a file on disk to package it in the final build
+	 * @brief Exports the locally available data to a file on disk to package it in the final build, returns true if the local file content was modified during the operation
 	 */
-	void ExportLocalTranslations(bool& WasModified);
+	bool ExportLocalTranslations();
 
 	// Begin UEditorSubsystem interface
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;

--- a/Source/TolgeeEditor/Private/TolgeeEditorIntegrationSubsystem.h
+++ b/Source/TolgeeEditor/Private/TolgeeEditorIntegrationSubsystem.h
@@ -30,7 +30,13 @@ public:
 	 */
 	void Sync();
 
+	void DownloadTranslationsJson();
+
 private:
+	bool EnsureFileCheckedOutSourceControl(FString FilePath);
+
+	bool EnsureFileFileAddedSourceControl(FString FilePath, bool bWasFileModified);
+	
 	/**
 	 * Sends a request to the backend to import new keys
 	 */
@@ -74,7 +80,7 @@ private:
 	/**
 	 * @brief Exports the locally available data to a file on disk to package it in the final build
 	 */
-	void ExportLocalTranslations();
+	void ExportLocalTranslations(bool& WasModified);
 
 	// Begin UEditorSubsystem interface
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;


### PR DESCRIPTION
This PR adds the features we need to have a workflow where Translations.json is manually pulled and versioned into Perforce + "Live Translations" are disabled and no automatic updates on cooking step.

* Added setting if translations should be fetched on cook
* Added menu button to fetch Translations.json manually
* Added support for version control when writing Translations.json file (if it was in Perforce the write would fail since the file was not checked out)