### PR TITLE
chore: Moved WebBrowserWidget plugin to Editor module

### DIFF
--- a/Tolgee.uplugin
+++ b/Tolgee.uplugin
@@ -34,6 +34,12 @@
 				"Linux",
 				"Mac",
 				"Win64"
+			],
+			"Plugins": [
+				{
+					"Name": "WebBrowserWidget",
+					"Enabled": true
+				}
 			]
 		},
 		{
@@ -45,12 +51,6 @@
 				"Mac",
 				"Linux"
 			]
-		}
-	],
-	"Plugins": [
-		{
-			"Name": "WebBrowserWidget",
-			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
For issue #35 

Moving the WebBrowserWidget to the Editor scope.
Having it in the packaged game caused a crash for us on Mac, but might be better in the editor scope either way.